### PR TITLE
Add Address Functionality

### DIFF
--- a/R/get_num_results-internal.R
+++ b/R/get_num_results-internal.R
@@ -21,7 +21,6 @@ get_num_results <- function(query)
     extract(1) %>%
     rvest::html_text() %>%
     as.numeric()
-  if(length(tot_results) == 0) tot_results = 0
 
   return(tot_results)
 }

--- a/R/get_num_results-internal.R
+++ b/R/get_num_results-internal.R
@@ -21,6 +21,7 @@ get_num_results <- function(query)
     extract(1) %>%
     rvest::html_text() %>%
     as.numeric()
+  if(length(tot_results) == 0) tot_results = 0
 
   return(tot_results)
 }

--- a/R/rentals.R
+++ b/R/rentals.R
@@ -141,10 +141,6 @@ rentals <- function(location = "seattle", area = "all", base_url = NULL,
 
   # How many results are available?
   tot_results <- get_num_results(query_url)
-  if(tot_results == 0){
-    message("No search results found.  Please check your input.")
-    return(NA)
-  }
   # Use user specified max results if it is less than the num. available results
   if(max_results < tot_results){
     tot_results <- max_results

--- a/R/rentals.R
+++ b/R/rentals.R
@@ -38,6 +38,7 @@
 #' is \code{FALSE}.
 #' @param pets_dog Logical specifying whether apartment must allow dogs. Default
 #' is \code{FALSE}.
+#' @param ... Additional arguments.
 #'
 #' @examples
 #'

--- a/R/rentals.R
+++ b/R/rentals.R
@@ -141,6 +141,10 @@ rentals <- function(location = "seattle", area = "all", base_url = NULL,
 
   # How many results are available?
   tot_results <- get_num_results(query_url)
+  if(tot_results == 0){
+    message("No search results found.  Please check your input.")
+    return(NA)
+  }
   # Use user specified max results if it is less than the num. available results
   if(max_results < tot_results){
     tot_results <- max_results

--- a/R/rentals.R
+++ b/R/rentals.R
@@ -51,7 +51,7 @@ rentals <- function(location = "seattle", area = "all", base_url = NULL,
                     search_distance = NULL, bedrooms = NULL, bathrooms = NULL,
                     min_price = NULL, max_price = NULL, min_sqft = NULL,
                     max_sqft = NULL, has_pic = FALSE, posted_today = FALSE,
-                    pets_cat = FALSE, pets_dog = FALSE)
+                    pets_cat = FALSE, pets_dog = FALSE, ...)
 {
   ## Preliminary input checks -----
   # Generate the base url based on specified location and area and make sure
@@ -153,7 +153,7 @@ rentals <- function(location = "seattle", area = "all", base_url = NULL,
   {
     if(i == 0){
       ## Nothing is appended to the URL for the first page
-      all_results <- get_query(query_url)
+      all_results <- get_query(query_url, ...)
     } else {
       ## Add page number
       if(length(queries) > 1){
@@ -165,7 +165,7 @@ rentals <- function(location = "seattle", area = "all", base_url = NULL,
       }
 
       ## Get the results from the current page
-      query_results <- get_query(query_page)
+      query_results <- get_query(query_page, ...)
 
       ## Bind the results from each page
       all_results <- rbind(all_results, query_results)

--- a/man/get_query.Rd
+++ b/man/get_query.Rd
@@ -4,13 +4,16 @@
 \alias{get_query}
 \title{get_query}
 \usage{
-get_query(query, type = "apa")
+get_query(query, type = "apa", get_address = F)
 }
 \arguments{
 \item{query}{The URL specifying the query}
 
 \item{type}{What type of thing you want to look up on craiglist.  Currently
 only apartment searches are available.  Default is \code{apa} for "apartment".}
+
+\item{get_address}{Logical specifying whether to extract address from posting.
+Requires reading html of post URL. Default is \code{FALSE}}
 }
 \value{
 

--- a/man/rentals.Rd
+++ b/man/rentals.Rd
@@ -9,7 +9,7 @@ rentals(location = "seattle", area = "all", base_url = NULL,
   postal = NULL, search_distance = NULL, bedrooms = NULL,
   bathrooms = NULL, min_price = NULL, max_price = NULL, min_sqft = NULL,
   max_sqft = NULL, has_pic = FALSE, posted_today = FALSE,
-  pets_cat = FALSE, pets_dog = FALSE)
+  pets_cat = FALSE, pets_dog = FALSE, ...)
 }
 \arguments{
 \item{location}{Character vector containing the region to look in. Matches
@@ -65,6 +65,8 @@ is \code{FALSE}.}
 
 \item{pets_dog}{Logical specifying whether apartment must allow dogs. Default
 is \code{FALSE}.}
+
+\item{...}{Additional arguments.}
 }
 \description{
 Get a list of housing available on craiglist using your own


### PR DESCRIPTION
Extracts .mapaddress from Craigslist rental ad. This requires reading html page for each posting, which increases the run-time and number of web pages to read. Therefore, included is logical argument to get_query function ( get_address, default is FALSE) on whether or not to extract address. If TRUE, Address column added to output dataframe. If FALSE, output same as before.

Ellipses added to rentals function so the arguments can be passed to get_query.
Use example:
```
rentals(location = "seattle", get_address = TRUE)
```