### PR TITLE
Fixes type error with newyork

### DIFF
--- a/R/get_base_url-internal.R
+++ b/R/get_base_url-internal.R
@@ -18,6 +18,9 @@
 #'
 get_base_url <- function(location, area, type = "apa")
 {
+  ##Check if location is newyork if so set type to aap as newyork uses aap while craiglist uses apa elsewhere
+  type <-ifelse(location == 'newyork', 'aap', type)
+
   ## Generate the base url
   if(area == "all"){
     return(paste0("https://", location, ".craigslist.org/search/", type))


### PR DESCRIPTION
type for newyork needs to be 'aap' because in new york they have apartments that you rent through a broker and non brokered apartments. aap is for all apartments.

currently when searching in newyork you get a url error that is because type 'apa' is non existent in new york city this fixes this bug.